### PR TITLE
[Feat] data_split_chunk.py & [Fix] compute_psd.py

### DIFF
--- a/Utils/compute_psd.py
+++ b/Utils/compute_psd.py
@@ -1,122 +1,72 @@
-import os
-import pandas as pd
-import numpy as np
-from scipy import signal
 import mne
-import matplotlib.pyplot as plt
-from sklearn.preprocessing import MinMaxScaler
-from mpl_toolkits.axes_grid1 import make_axes_locatable
+import numpy as np
+import pandas as pd
+from data_split_chunk import preprocess_data, split_data_into_chunks, ch_names, ch_types, sampling_freq, p_detrend, p_normalization
 
-def load_and_preprocess_data(filenames, sampling_freq, p_detrend, p_normalization):
-    eeg_raw = {}
+def calculate_and_save_psd(eeg_raw_split, filename, ch_names, ch_types, sampling_freq, fmin=4, fmax=36):
+    """
+    Calculate and save PSD for all channels of a given label.
     
-    for i, filename in enumerate(filenames):
-        temp_pd = pd.read_csv(filename)
-        temp_pd = temp_pd.drop(columns=['label'])
+    :param eeg_raw_split: Dictionary with chunked DataFrames
+    :param filename: Name for the output filename
+    :param ch_names: List of channel names
+    :param ch_types: List of channel types
+    :param sampling_freq: Sampling frequency
+    :param fmin: Minimum frequency for PSD calculation (Hz)
+    :param fmax: Maximum frequency for PSD calculation (Hz)
+    """
+    all_results = []
 
-        plt.figure()
-        plt.plot(temp_pd['#  2'])
-        plt.title(f"EEG Plot for label {i+1}")
-        plt.xlabel("csv rows")
-        plt.ylabel("EEG Signal Amplitude")
-        plt.show()
+    # Process each label
+    for label_index in eeg_raw_split.keys():
+        chunks = eeg_raw_split[label_index]
 
-        if p_detrend == 1:
-            temp_pd = detrend_df(temp_pd)
+        for chunk_index, chunk in enumerate(chunks):
+            # Create MNE Info object
+            info = mne.create_info(ch_names, ch_types=ch_types, sfreq=sampling_freq)
+            info.set_montage('standard_1020')
+            
+            info['description'] = 'OpenBCI'
+            info['bads'] = []  # Names of bad channels
+            
+            # Create RawArray object
+            raw = mne.io.RawArray(chunk.to_numpy(), info)
+            
+            # Calculate PSD for each channel
+            for channel_name in ch_names:
+                data_array = raw.get_data(picks=[channel_name])
+                sfreq = raw.info['sfreq']
+                
+                # Calculate PSD
+                psd, freqs = mne.time_frequency.psd_array_welch(data_array, sfreq=sfreq, fmin=fmin, fmax=fmax)
+                
+                # Convert psd to log scale
+                psd = 10. * np.log10(psd)
+                
+                # Save PSD result
+                for i in range(len(freqs)):
+                    all_results.append({
+                        'Label': label_index + 1,
+                        'Channel': channel_name,
+                        'Frequency': freqs[i],
+                        'PSD': psd[0][i]
+                    })
 
-        if p_normalization == 1:
-            scaler = MinMaxScaler()
-            temp_pd = pd.DataFrame(scaler.fit_transform(temp_pd), columns=temp_pd.columns)
-        elif p_normalization == 2:
-            scaler = StandardScaler()
-            temp_pd = pd.DataFrame(scaler.fit_transform(temp_pd), columns=temp_pd.columns)
-
-        temp_pd = temp_pd.transpose()
-        eeg_raw[i] = temp_pd
-
-    return eeg_raw
-
-def detrend_df(df):
-    detrended_data = {col: signal.detrend(df[col]) for col in df.columns}
-    detrended_df = pd.DataFrame(detrended_data)
-    return detrended_df
-
-def create_mne_raw_objects(eeg_raw, n_channels, sampling_freq, ch_names, ch_types):
-    mne_raw = {}
-
-    for i in range(len(eeg_raw)):
-        info = mne.create_info(n_channels, sfreq=sampling_freq)
-        info = mne.create_info(ch_names, ch_types=ch_types, sfreq=sampling_freq)
-        info.set_montage('standard_1020')
-        info['description'] = 'OpenBCI'
-        info['bads'] = []
-
-        raw = mne.io.RawArray(eeg_raw[i], info)
-        mne_raw[i] = raw
-    
-    return mne_raw
-
-def calculate_psd_for_all_channels(mne_raw_list, condition_names, fmin=4, fmax=36, freq_step=2):
-    for raw_idx, (mne_raw, condition_name) in enumerate(zip(mne_raw_list, condition_names)):
-        data_array = mne_raw.get_data(picks='all')
-        sfreq = mne_raw.info['sfreq']
-        channel_names = mne_raw.info['ch_names']
-
-        print(f"Condition: {condition_name}")
-
-        for channel_idx, channel_name in enumerate(channel_names):
-            channel_data = data_array[channel_idx]
-            psds, freqs = mne.time_frequency.psd_array_welch(channel_data, sfreq=sfreq, fmin=fmin, fmax=fmax)
-            psds = 10. * np.log10(psds)
-            mask = np.logical_and(freqs >= fmin, freqs <= fmax)
-            filtered_freqs = freqs[mask]
-            filtered_psds = psds[mask]
-
-            freq_indices = np.arange(0, len(filtered_freqs), int(freq_step / (freqs[1] - freqs[0])))
-            freq_indices = freq_indices[freq_indices < len(filtered_freqs)]
-            selected_freqs = filtered_freqs[freq_indices]
-            selected_psds = filtered_psds[freq_indices]
-
-            print(f"  Channel: {channel_name}")
-            print("  Frequencies:", selected_freqs)
-            print("  PSD values:", selected_psds)
-            print("\n")
+    # Save results to CSV
+    df = pd.DataFrame(all_results)
+    df.to_csv(filename, index=False)
 
 def main():
-    n_channels = 60
-    sampling_freq = 250
-    ch_names = [
-        'Fpz', 'Fp1', 'Fp2', 'AF3', 'AF4',
-        'Fz', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8',
-        'FT7', 'FT8', 'FC1', 'FC2', 'FC3', 'FC4', 'FC5', 'FC6', 'FCz',
-        'Cz', 'C1', 'C2','C3', 'C4', 'C5', 'C6', 'T7', 'T8',
-        'CPz', 'CP1', 'CP2', 'CP3', 'CP4', 'CP5', 'CP6', 'TP7', 'TP8',
-        'Pz', 'P1', 'P2','P3', 'P4', 'P5', 'P6', 'P7', 'P8',
-        'POz', 'PO3', 'PO4', 'PO5', 'PO6', 'PO7', 'PO8',
-        'Oz', 'O1', 'O2'
-    ]
-    ch_types = ['eeg'] * n_channels
-
-    p_detrend = 0
-    p_normalization = 0
-    p_ica_flag = 0
-    p_ts_psd_flag = 0
-
-    filenames = [f"C:/Users/windows/Desktop/EEG-GPT-main/Dataset/eeg_data_label_{i}.csv" for i in range(1, 6)]
+    filenames = [f"C:/Users/windows/Desktop/EEG-GPT-main/Dataset/laf_eeg_data_ch9_label{i}.csv" for i in range(1, 6)]
     
-    eeg_raw = load_and_preprocess_data(filenames, sampling_freq, p_detrend, p_normalization)
-    mne_raw = create_mne_raw_objects(eeg_raw, n_channels, sampling_freq, ch_names, ch_types)
+    # Preprocess data
+    eeg_raw = preprocess_data(filenames, p_detrend, p_normalization)
     
-    condition_names = ["right", "left", "tongue", "foot", "rest"]
-    calculate_psd_for_all_channels([mne_raw[i] for i in range(len(filenames))], condition_names)
-
-    mne_raw[0].plot_psd(fmax=50)
-    plt.show()  # First PSD plot
-
-    mne_raw[1].plot_psd(fmax=50)
-    plt.show()  # Second PSD plot
-
-    print('Done')
+    # Split data into chunks
+    eeg_raw_split = split_data_into_chunks(eeg_raw, chunk_size=1000)
+    
+    # Calculate and save PSD
+    calculate_and_save_psd(eeg_raw_split, 'psd_result.csv', ch_names, ch_types, sampling_freq)
 
 if __name__ == "__main__":
     main()

--- a/Utils/data_split_chunk.py
+++ b/Utils/data_split_chunk.py
@@ -1,0 +1,80 @@
+import pandas as pd
+import numpy as np
+from scipy import signal
+from sklearn.preprocessing import MinMaxScaler, StandardScaler
+
+# Setting
+n_channels = 9
+sampling_freq = 250  # in Hertz
+ch_names = [
+    'FC3', 'FCz', 'FC4',
+    'C3', 'Cz', 'C4',
+    'CP3', 'CPz', 'CP4'
+]
+ch_types = ['eeg'] * n_channels
+p_detrend = 0  # 0: OFF, 1: ON
+p_normalization = 0  # 0: do not, 1: [0, 1] scaling, 2: standardization (x-mean)/var
+
+def preprocess_data(filepaths, p_detrend, p_normalization):
+    """
+    Preprocess EEG data: Detrend and normalize if required.
+    
+    :param filepaths: List of file paths for CSV files
+    :param p_detrend: Flag for detrending (0: OFF, 1: ON)
+    :param p_normalization: Flag for normalization (0: OFF, 1: Min-Max, 2: Standardization)
+    :return: Dictionary with preprocessed DataFrames
+    """
+    eeg_raw = {}
+    
+    def detrend_df(df):
+        detrended_data = {col: signal.detrend(df[col]) for col in df.columns}
+        return pd.DataFrame(detrended_data)
+    
+    for i in range(len(filepaths)):
+        temp_pd = pd.read_csv(filepaths[i])
+        temp_pd = temp_pd.drop(columns=['label'])
+        
+        if p_detrend == 1:
+            temp_pd = detrend_df(temp_pd)
+        
+        if p_normalization == 1:
+            scaler = MinMaxScaler()
+            temp_pd = pd.DataFrame(scaler.fit_transform(temp_pd), columns=temp_pd.columns)
+        elif p_normalization == 2:
+            scaler = StandardScaler()
+            temp_pd = pd.DataFrame(scaler.fit_transform(temp_pd), columns=temp_pd.columns)
+        
+        temp_pd = temp_pd.transpose()
+        eeg_raw[i] = temp_pd
+    
+    return eeg_raw
+
+def split_columns(df, chunk_size=1000):
+    """
+    Split DataFrame into chunks of specified column size.
+    
+    :param df: DataFrame to split
+    :param chunk_size: Number of columns per chunk
+    :return: List of DataFrames split into chunks
+    """
+    df_list = []
+    num_cols = df.shape[1]
+    for i in range(0, num_cols, chunk_size):
+        df_chunk = df.iloc[:, i:i + chunk_size]
+        df_list.append(df_chunk)
+    return df_list
+
+def split_data_into_chunks(eeg_raw, chunk_size=1000):
+    """
+    Split the preprocessed EEG data into chunks.
+    
+    :param eeg_raw: Dictionary with preprocessed DataFrames
+    :param chunk_size: Number of columns per chunk
+    :return: Dictionary with chunked DataFrames
+    """
+    eeg_raw_split = {}
+    for i in range(len(eeg_raw)):
+        temp_pd = eeg_raw[i]
+        split_data = split_columns(temp_pd, chunk_size=chunk_size)
+        eeg_raw_split[i] = split_data
+    return eeg_raw_split


### PR DESCRIPTION
- data_split_chunk.py 코드 추가
1. Large Laplacian Filter가 적용된 csv 파일을 로드
2. 설정에 따라 preprocessing (detrend, normalization) 수행
3. 각 Label(1, 2, 3, 4, 5)마다 데이터를 1000 column씩 chunk로 잘라냄
cf) chunk로 자르는 이유는 fisher ratio를 구할 때 PSD의 mean과 variance가 필요한데, 이를 chunk 나눠서 구하기 때문임

- compute_psd.py 코드 수정

1. data_split_chunk.py를 모듈로 가져옴
2. 각 Label의 Channel마다 PSD를 구해서 psd_result.csv로 저장
3. csv 파일에 저장된 PSD 값은 mean과 variance를 구하는데 사용됨