### PR TITLE
 [Refactor] Refactoring 'compute_psd.py' & 'fisher_ratio.py'

### DIFF
--- a/Utils/compute_psd.py
+++ b/Utils/compute_psd.py
@@ -3,60 +3,93 @@ import numpy as np
 import pandas as pd
 from data_split_chunk import preprocess_data, split_data_into_chunks, ch_names, ch_types, sampling_freq, p_detrend, p_normalization
 
-def calculate_and_save_psd(eeg_raw_split, filename, ch_names, ch_types, sampling_freq, fmin=4, fmax=36):
+def calculate_psd_for_labels(eeg_raw_split, ch_names, ch_types, sampling_freq, fmin=4, fmax=36, output_csv='psd_results_2Hz.csv'):
     """
-    Calculate and save PSD for all channels of a given label.
-    
-    :param eeg_raw_split: Dictionary with chunked DataFrames
-    :param filename: Name for the output filename
-    :param ch_names: List of channel names
-    :param ch_types: List of channel types
-    :param sampling_freq: Sampling frequency
-    :param fmin: Minimum frequency for PSD calculation (Hz)
-    :param fmax: Maximum frequency for PSD calculation (Hz)
+    각 레이블의 데이터 조각에 대해 PSD를 계산하고 결과를 CSV 파일로 저장하는 함수
+
+    :param eeg_raw_split: 레이블별 데이터 조각 리스트
+    :param ch_names: 채널 이름 리스트
+    :param ch_types: 채널 타입 리스트
+    :param sampling_freq: 샘플링 주파수
+    :param fmin: PSD 계산의 최소 주파수 (Hz)
+    :param fmax: PSD 계산의 최대 주파수 (Hz)
+    :param output_csv: 결과를 저장할 CSV 파일 이름
     """
-    all_results = []
+    # 선택할 레이블의 데이터 조각
+    label_indices = range(1, len(eeg_raw_split) + 1)  # 레이블 인덱스를 1부터 시작하도록 변경
 
-    # Process each label
-    for label_index in eeg_raw_split.keys():
-        chunks = eeg_raw_split[label_index]
+    # 결과를 저장할 리스트
+    results = []
 
+    # 주파수 해상도를 2Hz로 설정하기 위한 n_fft 계산
+    n_fft = int(2 ** (np.ceil(np.log2(sampling_freq / 2))))  # 대략적인 n_fft 값
+
+    for label_index in label_indices:
+        # 선택한 레이블의 데이터 조각 (라벨 인덱스를 0 기반 인덱스로 변환)
+        chunks = eeg_raw_split[label_index - 1]
+        
+        # 각 채널과 chunk에 대한 PSD를 저장할 딕셔너리
+        all_psds = {channel_name: [] for channel_name in ch_names}
+        
+        # 각 chunk에 대해 PSD를 계산하고 저장
         for chunk_index, chunk in enumerate(chunks):
-            # Create MNE Info object
+            # MNE 객체 생성
             info = mne.create_info(ch_names, ch_types=ch_types, sfreq=sampling_freq)
             info.set_montage('standard_1020')
             
             info['description'] = 'OpenBCI'
             info['bads'] = []  # Names of bad channels
             
-            # Create RawArray object
+            # RawArray 객체 생성
             raw = mne.io.RawArray(chunk.to_numpy(), info)
             
-            # Calculate PSD for each channel
+            # 모든 채널에 대해 PSD 계산
             for channel_name in ch_names:
                 data_array = raw.get_data(picks=[channel_name])
                 sfreq = raw.info['sfreq']
                 
-                # Calculate PSD
-                psd, freqs = mne.time_frequency.psd_array_welch(data_array, sfreq=sfreq, fmin=fmin, fmax=fmax)
+                # PSD 계산
+                psd, freqs = mne.time_frequency.psd_array_welch(data_array, sfreq=sfreq, fmin=fmin, fmax=fmax, n_fft=n_fft)
                 
-                # Convert psd to log scale
+                # psd를 로그 스케일로 변환
                 psd = 10. * np.log10(psd)
                 
-                # Save PSD result
-                for i in range(len(freqs)):
-                    all_results.append({
-                        'Label': label_index + 1,
+                # PSD 결과 저장
+                all_psds[channel_name].append(psd[0])  # Assuming one channel per data array
+        
+        # 각 채널의 PSD 평균과 분산 계산
+        for channel_name in ch_names:
+            psds_for_channel = np.array(all_psds[channel_name])
+            mean_psd = np.mean(psds_for_channel, axis=0)
+            variance_psd = np.var(psds_for_channel, axis=0)  # Calculate variance
+            
+            # 2Hz 간격으로 평균과 분산 계산
+            for start_freq in range(4, 36, 2):
+                end_freq = start_freq + 2
+                mask = (freqs >= start_freq) & (freqs < end_freq)
+                if np.any(mask):  # mask가 비어있지 않으면
+                    mean = np.mean(mean_psd[mask])
+                    variance = np.mean(variance_psd[mask])
+                    
+                    # 결과 리스트에 추가
+                    results.append({
+                        'Label': label_index,  # 라벨을 1부터 시작하도록 유지
                         'Channel': channel_name,
-                        'Frequency': freqs[i],
-                        'PSD': psd[0][i]
+                        'Frequency_Band': f'{start_freq}-{end_freq}Hz',
+                        'Mean_PSD': mean,
+                        'Variance_PSD': variance
                     })
 
-    # Save results to CSV
-    df = pd.DataFrame(all_results)
-    df.to_csv(filename, index=False)
+    # 결과를 pandas DataFrame으로 저장
+    df = pd.DataFrame(results)
 
-def main():
+    # CSV 파일로 저장
+    df.to_csv(output_csv, index=False)
+
+    print(f"Results saved to {output_csv}")
+
+# 사용
+if __name__ == "__main__":
     filenames = [f"C:/Users/windows/Desktop/EEG-GPT-main/Dataset/laf_eeg_data_ch9_label{i}.csv" for i in range(1, 6)]
     
     # Preprocess data
@@ -66,7 +99,4 @@ def main():
     eeg_raw_split = split_data_into_chunks(eeg_raw, chunk_size=1000)
     
     # Calculate and save PSD
-    calculate_and_save_psd(eeg_raw_split, 'psd_result.csv', ch_names, ch_types, sampling_freq)
-
-if __name__ == "__main__":
-    main()
+    calculate_psd_for_labels(eeg_raw_split, ch_names, ch_types, sampling_freq)


### PR DESCRIPTION
- compute_psd.py
1. 계산된 psd를 2Hz 단위로 mean과 variance을 계산하고 csv 파일로 저장하도록 코드를 수정했습니다.
- fisher_ratio.py
1. 2Hz 단위로 fisher raio를 구하고 heatmap을 plot하도록 코드를 수정했습니다. 이 python 파일을 실행하고 생성되는 fisher_ratios.csv 파일을 이용해서 LLM에 학습시키면 됩니다.